### PR TITLE
Support child process kill of command

### DIFF
--- a/livereloadproxy/task.go
+++ b/livereloadproxy/task.go
@@ -56,7 +56,7 @@ func (t *Task) Callback(message string) {
 	go func() {
 		time.Sleep(t.aggregateTimeout)
 		for _, cmd := range t.commands {
-			cmd.Restart()
+			go cmd.Restart()
 		}
 		t.proxy.Reload(message)
 		t.isReloading = false


### PR DESCRIPTION
# Overview
+ Support child process kill of command
    + When `go run` executes, child process had existed.